### PR TITLE
kubernetes-volumes

### DIFF
--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secret.yaml
+++ b/kubernetes-volumes/minio-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-minio
+type: kubernetes.io/basic-auth
+stringData:
+  username: minio
+  password: minio123

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+           secretKeyRef:
+            name: secret-minio
+            key: username
+#          value: "minio"
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+           secretKeyRef:
+            name: secret-minio
+            key: password
+#          value: "minio123"
+        image: minio/minio:latest
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 200
+          periodSeconds: 50
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ № 5

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Развёрнут кластер с помощью kind (_export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" не срабатывала команда, не понимала консоль, что за флаг --name. Для чего эта команда?_)
 - запуск Minio с созданием PVC и PV. Были ошибки при создании pod "CrashLoopBackOff". Решил проблему увеличив в манифесте время в LivenessProbe:
```
  initialDelaySeconds: 200
          periodSeconds: 50
```

 - Применил minio-headlessservice.yaml
 - Проверил работу MinIO с помощью команд 
```
kubectl get statefulsets
kubectl get pods
kubectl get pvc
kubectl get pv
```
 - 

## Как запустить проект:
kind create cluster

## Как проверить работоспособность:
 - kind get clusters

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
